### PR TITLE
[feat] 소셜 로그인에도 이메일 주소 추가

### DIFF
--- a/server/apps/users/forms.py
+++ b/server/apps/users/forms.py
@@ -67,6 +67,15 @@ class SignupForm(UserCreationForm):
 
 
 class UpdateForm(forms.ModelForm):
+    username = forms.CharField(
+        label='아이디',
+        widget=forms.TextInput(
+            attrs={
+                'class': 'signup-input'
+            }
+        )
+    )
+
     nickname = forms.CharField(
         label='닉네임',
         widget=forms.TextInput(
@@ -91,7 +100,16 @@ class UpdateForm(forms.ModelForm):
             }
         )
     )
+    email = forms.CharField(
+        label='이메일',
+        widget=forms.TextInput(
+            attrs={
+                'class': 'signup-input'
+            }
+        )
+    )
 
     class Meta:
         model = User
         fields = ["nickname", "birth", "phone"]
+        fields = ['username', 'nickname', 'birth', 'phone', 'email']

--- a/server/apps/users/urls.py
+++ b/server/apps/users/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path("login/", views.login, name="login"),
     path("logout/", views.logout, name="logout"),
     path("signup/", views.signup, name="signup"),
+    path("delete/<int:pk>/", views.delete, name="delete"),
     path("update/<int:pk>/", views.update, name="update"),
 
     # 소셜 로그인 관련 기능

--- a/server/apps/users/views.py
+++ b/server/apps/users/views.py
@@ -147,17 +147,22 @@ def logout(request):
 @csrf_exempt
 def update(request, pk):
     user = User.objects.get(id=pk)
-    selected_city = request.POST.get('city')
-    selected_town = request.POST.get('town')
     if request.method == 'POST':
+        selected_city = request.POST.get('city')
+        selected_town = request.POST.get('town')
+        street_address = request.POST.get('street_address')
+        detail_address = request.POST.get('detail_address')
         form = UpdateForm(request.POST, instance=user)
         if form.is_valid():
             user = form.save(commit=False)
             region = Region.objects.filter(
                 city=selected_city, town=selected_town).first()
             user.region = region
+            user.address = street_address
+            user.detail_address = detail_address
             user.save()
-            return redirect('users:main', user.pk)
+            redirect_url = reverse('users:main', kwargs={'pk': user.pk})
+            return JsonResponse({'url': redirect_url})
         else:
             print("폼 유효성 검사 실패")
             print(form.errors)
@@ -169,12 +174,24 @@ def update(request, pk):
             'pk': pk,
             'city': user.region.city,
             'town': user.region.town,
+            'street_address': user.address,
+            'detail_address': user.detail_address,
         }
         return render(request, template_name='users/users_update.html', context=context)
 
+@csrf_exempt
+@login_required
+def delete(request, pk):
+    user = User.objects.get(id=pk)
+    if request.method == "POST":
+        if user.social_auth.filter(provider='kakao').exists():
+            kakao_unlink(request)
+        user.delete()
+        return redirect('home')
+    
 
 ###########################################################
-#                      소셜로그인 관련 함수             #
+#                      소셜로그인 관련 함수                #
 ###########################################################
 # 함수 이름 : social_login
 # 전달인자 : request
@@ -187,15 +204,35 @@ def social_login(request):
         user.first_login = False
         user.save()
         if request.method == 'POST':
+            selected_city = request.POST.get('city')
+            selected_town = request.POST.get('town')
+            street_address = request.POST.get('street_address')
+            detail_address = request.POST.get('detail_address')
             form = UpdateForm(request.POST, instance=user)
             if form.is_valid():
-                form.save()
-                return redirect('users:main', user.id)
+                user = form.save(commit=False)
+                region = Region.objects.filter(
+                city=selected_city, town=selected_town).first()
+                user.region = region
+                user.address = street_address
+                user.detail_address = detail_address
+                user.save()
+                redirect_url = reverse('users:main', kwargs={'pk': user.pk})
+                return JsonResponse({'url': redirect_url})
+            else:
+                print("폼 유효성 검사 실패")
+                print(form.errors)
+                return redirect('users:update', user.pk)
+
         else:
             form = UpdateForm(instance=user)
             context = {
                 'form': form,
-                'pk': user.id,
+                'pk': user.pk,
+                'city': None,
+                'town': None,
+                'street_address': None,
+                'detail_address': None,
             }
             return render(request, template_name='users/users_update.html', context=context)
 

--- a/server/config/settings.py
+++ b/server/config/settings.py
@@ -179,7 +179,7 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.0/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'ko'
 
 TIME_ZONE = 'Asia/Seoul'
 

--- a/server/static/users/js/update.js
+++ b/server/static/users/js/update.js
@@ -1,6 +1,9 @@
 document.addEventListener("DOMContentLoaded", function () {
   var cityField = document.getElementById("city");
   var townField = document.getElementById("town");
+  var addressField = document.getElementById("address_text");
+  var sbAddressField = document.getElementById("address_detail");
+
 
   // 1. city 선택 목록 보여주는 기능
   // city 데이터 DB에서 요청
@@ -82,10 +85,38 @@ document.addEventListener("DOMContentLoaded", function () {
     } else {
       formData.append("town", townField.value);
     }
+      
+    formData.append("street_address", addressField.value);
+    formData.append("detail_address", sbAddressField.value);
+    
     const url = `/users/update/${userId}/`;
     const xhr = new XMLHttpRequest();
     xhr.open("POST", url, true);
     xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+    xhr.onreadystatechange = function () {
+      if (xhr.readyState === 4 && xhr.status === 200) {
+        const data = JSON.parse(xhr.responseText);
+        window.location.replace(data.url);
+      }
+    };
     xhr.send(formData);
   });
 });
+
+function execDaumPostcode(event) {
+  event.preventDefault();
+  new daum.Postcode({
+    oncomplete: function (data) {
+      var address = "";
+
+      if (data.userSelectedType === "R") {
+        address = data.roadAddress;
+      } else {
+        address = data.jibunAddress;
+      }
+
+      document.getElementById("address_text").value = address;
+      document.getElementById("address_detail").focus(); // 커서를 상세주소 필드로 이동
+    },
+  }).open();
+}

--- a/server/templates/users/users_main.html
+++ b/server/templates/users/users_main.html
@@ -63,8 +63,9 @@
       <div class="user-btn-box">
         <h3 class="user-btn-title">계정</h3>
         <a href="{% url 'users:update' user.pk %}" class="user-mypage-btn">회원정보 수정</a>
-        <a href="{% url 'users:logout' %}" class="user-mypage-btn">로그아웃</a>
-        <a href="" class="user-mypage-btn">회원 탈퇴</a>
+        <form method="post" action="{% url 'users:delete' user.pk %}" class="user-mypage-btn">
+          <button type="submit">회원 탈퇴</button>
+        </form>
       </div>
     </div>
     

--- a/server/templates/users/users_signup.html
+++ b/server/templates/users/users_signup.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %} {%load static%} {% block content %}
-<form method="POST" action="{% static "/users/signup/" pk %}%}" id="signup-form"  class="signup-form">
+<form method="POST" action="{% static "/users/signup/" pk %}" id="signup-form"  class="signup-form">
   {{ form }}
   <div class="form-group">
     <!--도로명 주소 검색-->
@@ -15,13 +15,13 @@
 
     <label for="city">시/도:</label>
     <select id="city" class="signup-input">
-      <option value="">선택해주세요</option>
+      <option value="" disabled>선택해주세요</option>
     </select>
   </div>
   <div class="form-group">
     <label for="town">군/구:</label>
     <select id="town" class="signup-input">
-      <option value="">------</option>
+      <option value="" disabled>------</option>
     </select>
   </div>
   <button class="user-btn" type="submit" id="signup-form-submit" form="signup-form">회원가입</button>

--- a/server/templates/users/users_update.html
+++ b/server/templates/users/users_update.html
@@ -1,26 +1,54 @@
-{% extends 'base.html' %} {%load static%}
-
-{% block content %}
+{% extends 'base.html' %} {%load static%} {% block content %}
 <form method="POST" action="{% url 'users:update' pk %}" id="update-form" class="users-update-form">
-    {% csrf_token %}
-    {{ form }}
-    <div class="form-group">
+  {{ form }}
+  <div class="form-group">
+    <!--도로명 주소 검색-->
+    <label for="address_text">주소 입력</label>
+    <form id="address-form">
+      {% if street_address != None %}
+        <input type="text" value="{{street_address}}" name="address_text" readonly="readonly" id="address_text" />
+      {% else %}
+        <input type="text" placeholder="도로명 주소" name="address_text" readonly="readonly" id="address_text" />
+      {% endif %}
+      <button onclick="execDaumPostcode(event)" name="btn-address" form="address-form">
+        주소검색
+      </button>
+    </form>
+    <!--상세 주소-->
+    <p class="sb-addr">
+      {% if detail_address != None %}
+      <input type="text" class="w-xl" value="{{detail_address}}" name="address_detail" id="address_detail" />
+      {% else %}
+      <input type="text" class="w-xl" placeholder="상세주소" name="address_detail" id="address_detail" />
+      {% endif%}
+    </p>
+
+  <!--시도/군구 검색-->
     <label for="city">시/도:</label>
     <select id="city" class="update-input">
+      {% if city == None %}
+      <option value="" disabled>선택해주세요</option>
+      {% else %}
       <option value="">{{city}}</option>
+      {% endif %}
     </select>
-    </div>
-    <div class="form-group">
-      <label for="town">군/구:</label>
-      <select id="town" class="update-input">
-        <option value="">{{town}}</option>
-      </select>
-    </div>
-  <input type="submit" value="개인 정보 수정" class="user-btn" />
+  </div>
+  <div class="form-group">
+    <label for="town">군/구:</label>
+    <select id="town" class="update-input">
+      {% if town == None %}
+      <option value="">선택해주세요</option>
+      {% else %}
+      <option value="">{{town}}</option>
+      {% endif %}
+    </select>
+  </div>
+  <input type="submit" value="개인 정보 수정" class="user-btn" form="update-form" id="update-form-submit" />
 </form>
-{% endblock content %}
-
-{% block script %}
-<script>var userId = {{ request.user.pk }};</script>
+{% endblock content %} {% block script %}
+<script>
+  var userId = {{ request.user.pk }};
+</script>
 <script src="{% static 'users/js/update.js' %}"></script>
+<script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
 {% endblock script %}


### PR DESCRIPTION
1. 소셜로그인에 이메일. 주소 추가
2. 계정 삭제 기능 추가

[진행할 사항]
- 친구 이메일주소로 찾기
- 폼 유효성 검증 시각화